### PR TITLE
fix: use cookie-based auth for abandon cart API

### DIFF
--- a/src/services/request.js
+++ b/src/services/request.js
@@ -1,5 +1,5 @@
 import axios from "axios"
-import { medusaUrl, VITE_MEDUSA_BACKEND_URL } from "./config"
+import { medusaUrl } from "./config"
 
 const client = axios.create({ baseURL: medusaUrl })
 
@@ -15,26 +15,9 @@ export default function medusaRequest(method, path = "", payload = {}) {
 }
 
 export function backendRequest(path) {
-  const fullUrl = VITE_MEDUSA_BACKEND_URL + path
-  console.log("🐛 DEBUG - backendRequest:")
-  console.log("  fullUrl:", fullUrl)
-  
-  return fetch(fullUrl, {
+  return client({
     method: 'GET',
-    headers: {
-      "Authorization": "Bearer 12345678900"
-    }
-  }).then(async (response) => {
-    console.log("🐛 DEBUG - Response status:", response.status)
-    
-    if (!response.ok) {
-      const errorText = await response.text()
-      console.log("🐛 DEBUG - Response error:", errorText)
-      throw new Error(`HTTP ${response.status}: ${errorText}`)
-    }
-    
-    const data = await response.json()
-    console.log("🐛 DEBUG - Response data:", data)
-    return data
-  })
+    url: path,
+    withCredentials: true,
+  }).then((response) => response.data)
 }


### PR DESCRIPTION
## Summary
- Fixed 401 Unauthorized error on `/admin/abandon_cart/all` by replacing hardcoded Bearer token with cookie-based session auth
- `backendRequest` now uses the existing axios client with `withCredentials: true`, matching how all other admin endpoints authenticate

## Test plan
- [ ] Deploy to staging
- [ ] Navigate to https://medusa-admin.designereditions.com/a/checkouts/
- [ ] Verify abandoned carts load without 401 errors