### PR TITLE
Remove the dead Re-Send Mail action from order timeline emails

### DIFF
--- a/src/components/molecules/timeline-events/notification/index.tsx
+++ b/src/components/molecules/timeline-events/notification/index.tsx
@@ -1,11 +1,8 @@
-import React, { useState } from "react"
+import React from "react"
 import { NotificationEvent } from "../../../../hooks/use-build-timeline"
 import ArrowRightIcon from "../../../fundamentals/icons/arrow-right-icon"
 import MailIcon from "../../../fundamentals/icons/mail-icon"
-import SendIcon from "../../../fundamentals/icons/send-icon"
-import EventActionables from "../event-actionables"
 import EventContainer from "../event-container"
-import ResendModal from "./resend-modal"
 
 type NotificationProps = {
   event: NotificationEvent
@@ -19,36 +16,18 @@ const notificationTitleMap = {
 }
 
 const Notification: React.FC<NotificationProps> = ({ event }) => {
-  const [showResend, setShowResend] = useState(false)
-
-  const actions = (
-    <EventActionables
-      actions={[
-        {
-          label: "Re-Send Mail",
-          icon: <SendIcon size={20} />,
-          onClick: () => setShowResend(true),
-        },
-      ]}
-    />
-  )
+  // No "Re-Send Mail" action here. It posted to Medusa's own
+  // /admin/notifications/:id/resend, which looks up the provider that wrote the
+  // row -- sendgrid on anything older than 6 August 2026 -- and that provider no
+  // longer exists, so the button could only ever error. Resending goes through
+  // the "Send order confirmation" action, which sends via Brevo.
   return (
-    <>
-      <EventContainer
-        icon={<MailIcon size={20} />}
-        title={notificationTitleMap[event.title] || event.title}
-        time={event.time}
-        topNode={actions}
-        midNode={<ReceiverNode email={event.to} />}
-      />
-      {showResend && (
-        <ResendModal
-          handleCancel={() => setShowResend(false)}
-          notificationId={event.id}
-          email={event.to}
-        />
-      )}
-    </>
+    <EventContainer
+      icon={<MailIcon size={20} />}
+      title={notificationTitleMap[event.title] || event.title}
+      time={event.time}
+      midNode={<ReceiverNode email={event.to} />}
+    />
   )
 }
 


### PR DESCRIPTION
## Problem

Clicking **Re-Send Mail** on an order timeline email returns:

> Error — Could not find a notification provider with id: sendgrid.

The action calls `useAdminResendNotification`, which posts to Medusa's core `POST /admin/notifications/:id/resend`. That route resolves the notification provider that originally wrote the row and asks it to send again. The SendGrid plugin was removed from the shared backend on 2026-08-06 (`c6dd7d7`), so every pre-existing row names a provider that is no longer in the container, and Brevo is not registered as a notification provider at all — Medusa only registers those from plugins.

The button could not work for any order, old or new.

## Change

Removes the `Re-Send Mail` action and the modal it opened from `timeline-events/notification`.

Resending an order confirmation is already covered by the order-level **Send order confirmation** action, which goes through Brevo.

## Not changed

`resend-modal.tsx` stays — `timeline-events/order-edit/requested.tsx` still uses it for *Resend Confirmation-Request*. That button hits the same dead core route and will fail the same way; out of scope here.

## Verification

Docker build passes with the production build args. `Re-Send Mail` no longer appears in the built bundle; `Send order confirmation` still does.

Ticket: DE-54
